### PR TITLE
If expanded already bugfix

### DIFF
--- a/lib/AnimakitExpander.es6
+++ b/lib/AnimakitExpander.es6
@@ -211,7 +211,7 @@ export default class AnimakitExpander extends Component {
     }
 
     const prepare = !curPrepare && (curExpanded !== expanded);
-    const animation = !prepare;
+    const animation = !prepare && !expanded;
     const duration = animation ? this.calcDuration(expanded ? size : 0) : 0;
 
     const state = { expanded, size, prepare, animation, duration };


### PR DESCRIPTION
Hi, @askd!

We've faced a problem with a popup which contains expanded block by default. When it doesn't contain any content, but it is expanded, `onTransitionEnd` never triggered. That's why `getRootStyles()` always returns styling including fixed height, so overflow content (in my example it is a button) is hidden.

<img src="http://squirrel-research.ru/wp-content/uploads/2017/06/overflow-bug.gif" alt="GIF example" align="center" width="600" height="325" />

As a temporary solution, I've added ` && !expanded;` and looks like it works correctly now, but maybe there is a better solution.

Looking forward to your review!

Thanks!