### PR TITLE
Bugfix + minor perf improvement

### DIFF
--- a/lib/AnimakitExpander.es6
+++ b/lib/AnimakitExpander.es6
@@ -10,7 +10,7 @@ export default class AnimakitExpander extends Component {
     this.state = {
       animation: false,
       prepare: false,
-      expanded: false,
+      expanded: !!props.expanded,
 
       size: 0,
 

--- a/lib/AnimakitExpander.es6
+++ b/lib/AnimakitExpander.es6
@@ -16,6 +16,9 @@ export default class AnimakitExpander extends Component {
 
       duration: 0,
     };
+
+    this.setRootNode = this.setRootNode.bind(this);
+    this.setContentNode = this.setContentNode.bind(this);
   }
 
   componentWillMount() {
@@ -233,6 +236,14 @@ export default class AnimakitExpander extends Component {
     }
   }
 
+  setRootNode(c) {
+    this.rootNode = c;
+  }
+
+  setContentNode(c) {
+    this.contentNode = c;
+  }
+
   render() {
     const { animation, expanded, prepare } = this.state;
     const showChildren = expanded || prepare || animation;
@@ -240,11 +251,11 @@ export default class AnimakitExpander extends Component {
 
     return (
       <div
-        ref={(c) => { this.rootNode = c; }}
+        ref={this.setRootNode}
         style={ showChildren ? this.getRootStyles() : {} }
       >
         <div
-          ref={(c) => { this.contentNode = c; }}
+          ref={this.setContentNode}
           style={ showChildren ? this.getContentStyles() : {} }
         >
           { showChildren && hasChildren && this.getClearance() }


### PR DESCRIPTION
If I want to render the component initially as expanded, the component renders first as collapsed and than in few milliseconds re-renders as expanded. It is causing flashing e.g. if you have more expanders in the list.
This PR is fixing this behaviour by setting correct expanded state on the components constructor from props.